### PR TITLE
Fix crafting emitters staying active for canceled tasks

### DIFF
--- a/src/main/java/com/buuz135/refinedstoragerequestify/proxy/block/network/NetworkNodeCraftingEmitter.java
+++ b/src/main/java/com/buuz135/refinedstoragerequestify/proxy/block/network/NetworkNodeCraftingEmitter.java
@@ -64,7 +64,7 @@ public class NetworkNodeCraftingEmitter extends NetworkNode implements IType {
         super.update();
         if (network == null) return;
         if (canUpdate() && ticks % 4 == 0 && (craftingTask == null || !network.getCraftingManager().getTasks().contains(craftingTask))) {
-            if (craftingTask != null && craftingTask.getCompletionPercentage() == 100) {
+            if (craftingTask != null && (craftingTask.getCompletionPercentage() == 100 || !network.getCraftingManager().getTasks().contains(craftingTask))) {
                 this.craftingTask = null;
                 updateState();
             }


### PR DESCRIPTION
haven't compiled & tested it, got stuck on  the `No Minecraft version configured for project 307788` gradle error 😅 